### PR TITLE
Prefix and Suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ The number of milliseconds you're trying to beat. If your action takes more than
 
 Defaults to 100. Is that optimistic? Yeah, probably.
 
+    prefix
+    
+A string to be prepended to the output before the scolding
+
+    suffix
+    
+A string to be appended to the output after the scolding
+
 ### Overriding
 
 You can override the default configuration by creating an initializer (e.g. `config/intitializers/look_of_performance.rb`) and setting the values yourself, like so:

--- a/lib/look_of_performance/configuration.rb
+++ b/lib/look_of_performance/configuration.rb
@@ -41,6 +41,5 @@ module LookOfPerformance
     def self.suffix=(suffix)
       @suffix = suffix
     end
-    
   end
 end

--- a/lib/look_of_performance/configuration.rb
+++ b/lib/look_of_performance/configuration.rb
@@ -25,5 +25,22 @@ module LookOfPerformance
     def self.limit=(limit)
       @limit = limit
     end
+    
+    def self.prefix
+      @prefix || ""
+    end
+
+    def self.prefix=(prefix)
+      @prefix = prefix
+    end
+    
+    def self.suffix
+      @suffix || ""
+    end
+    
+    def self.suffix=(suffix)
+      @suffix = suffix
+    end
+    
   end
 end

--- a/lib/look_of_performance/output.rb
+++ b/lib/look_of_performance/output.rb
@@ -6,7 +6,16 @@ module LookOfPerformance
     end
 
     def to_s
-      (1..times).map { |_| scolding }.join(delimiter)
+      
+      
+      str = (1..times).map { |_| scolding }.join(delimiter)
+      
+      if !str.empty?
+        return "( ͡° ͜ʖ ͡°)╯╲___#{str} Don't mind me just taking my developers for a walk"
+      else
+        return ""
+      end
+      
     end
 
     def sendable?

--- a/lib/look_of_performance/output.rb
+++ b/lib/look_of_performance/output.rb
@@ -10,11 +10,11 @@ module LookOfPerformance
       
       str = (1..times).map { |_| scolding }.join(delimiter)
       
-      if !str.empty?
-        return "( ͡° ͜ʖ ͡°)╯╲___#{str} Don't mind me just taking my developers for a walk"
-      else
-        return ""
-      end
+      return "" if str.empty?
+      
+      [prefix, str, suffix].join(delimiter)
+      
+      
       
     end
 
@@ -41,5 +41,15 @@ module LookOfPerformance
     def delimiter
       config.delimiter
     end
+    
+    def prefix
+      config.prefix
+    end
+    
+    def suffix
+      config.suffix
+    end
+    
+    
   end
 end

--- a/lib/look_of_performance/output.rb
+++ b/lib/look_of_performance/output.rb
@@ -6,16 +6,11 @@ module LookOfPerformance
     end
 
     def to_s
-      
-      
       str = (1..times).map { |_| scolding }.join(delimiter)
       
       return "" if str.empty?
       
       [prefix, str, suffix].join(delimiter)
-      
-      
-      
     end
 
     def sendable?
@@ -49,7 +44,5 @@ module LookOfPerformance
     def suffix
       config.suffix
     end
-    
-    
   end
 end

--- a/spec/lib/look_of_performance/output_spec.rb
+++ b/spec/lib/look_of_performance/output_spec.rb
@@ -6,6 +6,8 @@ module LookOfPerformance
   TestConfig = OpenStruct.new(
     scolding:  'slow',
     delimiter: ' ',
+    prefix: "(o_o)",
+    suffix: "don't mind me just taking my developers for a walk",
     limit:     100
   )
 
@@ -17,7 +19,7 @@ module LookOfPerformance
       let(:duration) { 200 }
 
       it 'is the output string joined by delimiter the right number of times' do
-        expect(output.to_s).to eq 'slow slow'
+        expect(output.to_s).to eq "(o_o) slow slow don't mind me just taking my developers for a walk"
       end
     end
 


### PR DESCRIPTION
Updated tests and changed fixed string to a configurable prefix and suffix. Readme also updated with new options.

Example:

Initializer contains lines:

```
LookOfPerformance::Configuration.prefix = "( ͡° ͜ʖ ͡°) ╯╲___"
LookOfPerformance::Configuration.suffix = "Don't mind me, just taking my developers for a walk"
```

And output is:

```
( ͡° ͜ʖ ͡°) ╯╲___ ಠ_ಠ ಠ_ಠ Don't mind me, just taking my developers for a walk
Completed 200 OK in 233ms (Views: 230.9ms | ActiveRecord: 0.0ms)
```
